### PR TITLE
Sort content types alphabetically

### DIFF
--- a/src/components/Dialog/EntryPickerDialog.tsx
+++ b/src/components/Dialog/EntryPickerDialog.tsx
@@ -47,6 +47,8 @@ const EntryPickerDialog = (props:EntryPickerProps) => {
     setQuery(e.target.value)
   }
 
+  const compareContentTypesByName = (a: ContentType, b: ContentType) => a.name.localeCompare(b.name)
+
   useEffect(() => {
     let init = createClient({
       space: spaceConfig.id,
@@ -60,7 +62,7 @@ const EntryPickerDialog = (props:EntryPickerProps) => {
   useEffect(() => {
     if (client) {
       client.getContentTypes()
-      .then(res => setContentTypes(res.items))
+      .then(res => setContentTypes(res.items.sort(compareContentTypesByName)))
     }
 
   }, [client])


### PR DESCRIPTION
Currently the content types of the remote space are retrieved by order given from the remote space, which seems to be by creation date of the content type.
Editors are used to have the selection in alphabetical order, thus an alphabetical order is used for the content types as well.